### PR TITLE
Bannerimage: check if $url variable is empty

### DIFF
--- a/Block/Html/BannerImage.php
+++ b/Block/Html/BannerImage.php
@@ -29,13 +29,15 @@ class BannerImage extends \Magento\Cms\Block\Page
     {
         $url = $this->_filterProvider->getPageFilter()->filter($this->getPage()->getBannerImage());
 
+        if (empty($url)) {
+            return '';
+        }
+        
         $fullImageUrl = $this->_helper->get('cms/bannerimage/' . $url);
 
         $html = "<img class='cms-banner-image' src='$fullImageUrl' />";
 
-        if (!empty($url)) {
-            return $html;
-        }
+        return $html;
     }
 
     public function getImageUrl()

--- a/Block/Html/BannerImage.php
+++ b/Block/Html/BannerImage.php
@@ -33,7 +33,9 @@ class BannerImage extends \Magento\Cms\Block\Page
 
         $html = "<img class='cms-banner-image' src='$fullImageUrl' />";
 
-        return $html;
+        if (!empty($url)) {
+            return $html;
+        }
     }
 
     public function getImageUrl()


### PR DESCRIPTION
Evaluate with empty() the $url variable to fix img element with broken URL showing without given an URL.