### PR TITLE
Banner Image: add the HTML container. Add banner text

### DIFF
--- a/Block/Html/Banner.php
+++ b/Block/Html/Banner.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace OuterEdge\Base\Block\Html;
+
+class Banner extends \Magento\Cms\Block\Page
+{
+    /**
+     * Prepare HTML content
+     *
+     * @return string
+     */
+    protected function _toHtml()
+    {
+        $html = $this->_filterProvider->getPageFilter()->filter($this->getPage()->getBannerText());
+        return $html;
+    }
+}

--- a/Block/Html/BannerImage.php
+++ b/Block/Html/BannerImage.php
@@ -35,7 +35,7 @@ class BannerImage extends \Magento\Cms\Block\Page
         
         $fullImageUrl = $this->_helper->get('cms/bannerimage/' . $url);
 
-        $html = "<img class='cms-banner-image' src='$fullImageUrl' />";
+        $html = "<div class='cms-banner__image'><img class='cms-banner-image' src='$fullImageUrl' /></div>";
 
         return $html;
     }

--- a/Setup/UpgradeSchema.php
+++ b/Setup/UpgradeSchema.php
@@ -22,6 +22,13 @@ class UpgradeSchema implements UpgradeSchemaInterface
                     'type' =>\Magento\Framework\DB\Ddl\Table::TYPE_TEXT,
                     'comment' => 'Banner Image'
                 ]);
+
+            $connection->addColumn('cms_page','banner_text',
+                [
+                    'type' =>\Magento\Framework\DB\Ddl\Table::TYPE_TEXT,
+                    'comment' => 'Banner Text'
+                ]);
+                
             $installer->endSetup();
         }
 

--- a/view/adminhtml/ui_component/cms_page_form.xml
+++ b/view/adminhtml/ui_component/cms_page_form.xml
@@ -17,5 +17,19 @@
                 </item>
             </argument>
         </field>
+         <field name="banner_text">
+            <argument name="data" xsi:type="array">
+                <item name="config" xsi:type="array">
+                    <item name="label" xsi:type="string" translate="true">Banner Text</item>
+                    <item name="formElement" xsi:type="string">wysiwyg</item>
+                    <item name="source" xsi:type="string">page</item>
+                    <item name="wysiwyg" xsi:type="boolean">true</item>
+                    <item name="dataScope" xsi:type="string">banner_text</item>
+                    <item name="additionalClasses" xsi:type="string">admin__field-wide</item>
+                </item>
+            </argument>
+        </field>
     </fieldset>
 </form>
+
+

--- a/view/frontend/layout/cms_page_view.xml
+++ b/view/frontend/layout/cms_page_view.xml
@@ -2,7 +2,13 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceContainer name="content">
-            <block class="OuterEdge\Base\Block\Html\BannerImage" name="cms.page.banner.image" after="cms_page" />
+            <container name="cms.page.banner.container" htmlTag="section" htmlClass="cms-banner__container">
+                <block class="OuterEdge\Base\Block\Html\BannerImage" name="cms.page.banner.image"/>
+                <container name="cms.page.banner.text.container" htmlTag="div" htmlClass="cms-banner__content">
+                    <block class="OuterEdge\Base\Block\Html\Banner" name="cms.page.banner.text" after="-" />
+                </container>
+            </container>
         </referenceContainer>
+        <move element="cms.page.banner.container" destination="page.wrapper" before="main.content"/>  
     </body>
 </page>


### PR DESCRIPTION
**Add Banner Text to CMS Page.**
In addition to Banner Image add a text area (wysiwyg) that will return within the banner container.

**Banner Image**
Wrap the img element in a HTML container.